### PR TITLE
Add Vue 3 demo and modern export

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ npm run start:docs
 ## README of GmapVue
 
 You can read the plugin's README file following [this link](https://github.com/diegoazh/gmap-vue/blob/master/packages/gmap-vue/README.md).
+
+## Quick demo
+
+You can see a minimal Vue 3 setup using the plugin in [demo/usage.js](demo/usage.js). This file shows how to mount a simple map with a couple of markers using the new default export.

--- a/demo/usage.js
+++ b/demo/usage.js
@@ -1,0 +1,34 @@
+import { createApp } from 'vue';
+import GmapVue from '../packages/gmap-vue';
+
+const App = {
+  data() {
+    return {
+      markers: [
+        { position: { lat: 10, lng: 10 } },
+        { position: { lat: 11, lng: 11 } },
+      ],
+      center: { lat: 10, lng: 10 },
+    };
+  },
+  template: `
+    <GmapMap :center="center" :zoom="7" style="width:500px;height:300px">
+      <GmapMarker
+        v-for="(m, i) in markers"
+        :key="i"
+        :position="m.position"
+        @click="center = m.position"
+      />
+    </GmapMap>
+  `,
+};
+
+createApp(App)
+  .use(GmapVue, {
+    load: {
+      key: 'YOUR_API_KEY',
+      libraries: 'places',
+    },
+  })
+  .mount('#app');
+

--- a/packages/gmap-vue/README.md
+++ b/packages/gmap-vue/README.md
@@ -78,10 +78,11 @@ If you are using Webpack and Vue file components, just add the following to your
 In your `main.js` or inside a Nuxt plugin:
 
 ```js
-import Vue from 'vue'
-import * as VueGoogleMaps from 'gmap-vue'
+import { createApp } from 'vue'
+import GmapVue from 'gmap-vue'
 
-Vue.use(VueGoogleMaps, {
+const app = createApp(App)
+app.use(GmapVue, {
   load: {
     key: 'YOUR_API_TOKEN',
     libraries: 'places', // This is required if you use the Autocomplete plugin
@@ -106,6 +107,7 @@ Vue.use(VueGoogleMaps, {
   //// If you want to automatically install all the components this property must be set to 'true':
   installComponents: true
 })
+app.mount('#app')
 ```
 
 If you need to gain access to the `Map` instance (e.g. to call `panToBounds`, `panTo`):

--- a/packages/gmap-vue/package.json
+++ b/packages/gmap-vue/package.json
@@ -2,7 +2,7 @@
   "name": "gmap-vue",
   "version": "1.4.0",
   "description": "This is a google map component for Vue.js, updated for Vue 2 compatibility",
-  "main": "dist/main.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "npm run build:babel && npm run build:webpack",
     "build:babel": "rimraf ./dist && shx mkdir -p ./dist && cross-env BUILD_DEV=1 babel src -D --out-dir ./dist && echo {} > dist/.babelrc",

--- a/packages/gmap-vue/src/index.js
+++ b/packages/gmap-vue/src/index.js
@@ -1,0 +1,6 @@
+export * from './main';
+import { install } from './main';
+
+export default {
+  install,
+};


### PR DESCRIPTION
## Summary
- provide default export via new `src/index.js`
- update package entry point
- showcase modern usage in package README
- mention demo in root README
- add Vue 3 demo usage file

## Testing
- `npm test` *(fails: lerna not found)*
- `npm run lint` *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416935036c832dbe76e5a89a3ab54a